### PR TITLE
[PLATFORM-1960] Add topics to repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,6 @@
+
+repository:
+  # See https://github.com/apps/settings for all available settings.
+  name: python-home-test
+  description: null
+  topics: "squad::Core-Finance, mission::Pipes, product::Pipes, environment::Sandbox"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,4 +3,4 @@ repository:
   # See https://github.com/apps/settings for all available settings.
   name: python-home-test
   description: null
-  topics: "squad::Core-Finance, mission::Pipes, product::Pipes, environment::Sandbox"
+  topics: squad-core-finance, mission-pipes, product-pipes, environment-sandbox

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,4 +3,4 @@ repository:
   # See https://github.com/apps/settings for all available settings.
   name: python-home-test
   description: null
-  topics: squad-core-finance, mission-pipes, product-pipes, environment-sandbox
+  topics: squad-platform-team, mission-platform, product-platform, environment-sandbox


### PR DESCRIPTION
In order to easily group GitHub repositories together, we utilise topics to act as labels. We assign a squad to each repository to act as the main point of contact. Read more here: https://oaknorth-bank.atlassian.net/wiki/spaces/ENG/pages/287670416/GitHub+Topics